### PR TITLE
`window.onload` overwrite removed

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,7 +28,13 @@ function add_scripts()
     $Q_SCRIPTS = array("js/clipboard.js");
 
     foreach ($Q_SCRIPTS as $script) {
-        wp_enqueue_script("Qamar_" . $script, Q_PLUGIN_SOURCE . $script);
+        wp_enqueue_script(
+            "Qamar_" . $script,
+            Q_PLUGIN_SOURCE . $script,
+            array(),
+            '1.0.0', 
+            array('strategy'  => 'defer')
+        );
     }
 }
 add_action('wp_enqueue_scripts', 'add_scripts');

--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -9,7 +9,7 @@ const copy = (e) => {
     setTimeout(() => e.target.classList.remove("qCopied"), 1000);
 }
 
-window.onload = () => document
+document
     .querySelectorAll(".qClickToCopyText")
     .forEach(el => el.addEventListener("click", copy))
 


### PR DESCRIPTION
We removed the `window.onload=<func>` because it was overwriting the `onload` property, Now we use the strategy defer in `$args` of `wp_enqueue_script` function, This will add the defer attribute to `<script>` tag e.g. `<script defer ...>`.